### PR TITLE
Add seed script

### DIFF
--- a/Docker/seed.sh
+++ b/Docker/seed.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+if [ -z "${MYSQL_HOST}" ] || [ -z "${MYSQL_DATABASE}" ] || [ -z "${MYSQL_USER}" ] || [ -z "${MYSQL_PASSWORD}" ]; then 
+  echo "One or more MySQL environment variables not found"
+  echo "   - MYSQL_HOST"
+  echo "   - MYSQL_DATABASE"
+  echo "   - MYSQL_USER"
+  echo "   - MYSQL_PASSWORD"
+  echo "Cannot connect to the database to seed"
+  echo "Exiting..."
+  exit 1
+fi
+
+mysql \
+  --host=$MYSQL_HOST \
+  --user=$MYSQL_USER \
+  --password=$MYSQL_PASSWORD \
+  -e "
+-- select the database
+USE $MYSQL_DATABASE;
+
+-- create the tables
+CREATE TABLE IF NOT EXISTS student (
+  student_id  INT PRIMARY KEY,
+  first_name  VARCHAR(64) NOT NULL,
+  last_name   VARCHAR(64) NOT NULL
+);
+CREATE TABLE IF NOT EXISTS professor (
+  professor_id  INT PRIMARY KEY,
+  first_name    VARCHAR(64) NOT NULL,
+  last_name     VARCHAR(64) NOT NULL
+);
+CREATE TABLE IF NOT EXISTS course (
+  course_id     INT PRIMARY KEY,
+  name          VARCHAR(64) NOT NULL,
+  professor_id  INT NOT NULL REFERENCES professor(professor_id)
+);
+CREATE TABLE IF NOT EXISTS student_course (
+  course_id     INT,
+  student_id    INT,
+  PRIMARY KEY (course_id, student_id)
+);
+
+-- seed the tables with some default info
+INSERT INTO student (
+  student_id,
+  first_name,
+  last_name
+)
+VALUES (
+  1,
+  'Andrew',
+  'Bazen'
+), (
+  2,
+  'Austen',
+  'Jarosz'
+), (
+  3,
+  'Ben',
+  'Merritt'
+)
+ON DUPLICATE KEY UPDATE student_id=student_id;
+
+INSERT INTO professor (
+  professor_id,
+  first_name,
+  last_name
+)
+VALUES (
+  1,
+  'Jeffrey',
+  'Hemmes'
+)
+ON DUPLICATE KEY UPDATE professor_id=professor_id;
+
+INSERT INTO course (
+  course_id,
+  name,
+  professor_id
+) VALUES (
+  1,
+  'Distributed Systems',
+  1
+)
+ON DUPLICATE KEY UPDATE course_id=course_id;
+
+INSERT INTO student_course (
+  course_id,
+  student_id
+) VALUES (
+  1,
+  1
+), (
+  1,
+  2
+), (
+  1,
+  3
+)
+ON DUPLICATE KEY UPDATE course_id=course_id;
+"


### PR DESCRIPTION
# Changelog
- Add a seed script for some default data

# Usage
To seed the database, run 
`./Docker/seed.sh`

If you get an error about permissions, try 
`chmod +x ./Docker/seed.sh`

Note that you need to specify some environment variables.
If run outside of the docker container, the defaults should be something similar to 
```
MYSQL_HOST=127.0.0.1
MYSQL_DATABASE=my_database
MYSQL_USER=root
MYSQL_PASSWORD=root
```
If run inside the docker, the hostname will be the container name `mysql`